### PR TITLE
chore(dependabot): ignore eslint v10+ until plugin support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
       time: "03:00"
     # Limit to 5 open PRs at a time
     open-pull-requests-limit: 5
-    # Optional: ignore certain dependencies
-    # ignore:
-    #   - dependency-name: "express"
-    #     versions:
-    #       - "5.x"
+    # Keep eslint updates flowing, but block unsupported v10+ major line for now.
+    ignore:
+      - dependency-name: "eslint"
+        versions:
+          - ">=10.0.0"


### PR DESCRIPTION
## Summary
- add Dependabot ignore rule for `eslint` `>=10.0.0`
- keep regular dependency updates flowing

## Why
Dependabot PR #58 fails CI because `eslint-plugin-import@2.32.0` does not yet support ESLint 10. This prevents repeated failing major bump PRs until compatibility lands.
