### PR TITLE
chore(dependabot): ignore @eslint/js v10+ temporarily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,11 @@ updates:
       time: "03:00"
     # Limit to 5 open PRs at a time
     open-pull-requests-limit: 5
-    # Keep eslint updates flowing, but block unsupported v10+ major line for now.
+    # Block incompatible ESLint 10 major-line bumps until ecosystem support is ready.
     ignore:
       - dependency-name: "eslint"
+        versions:
+          - ">=10.0.0"
+      - dependency-name: "@eslint/js"
         versions:
           - ">=10.0.0"


### PR DESCRIPTION
## Summary
- add Dependabot ignore rule for `@eslint/js` `>=10.0.0`
- avoid opening incompatible major bump PRs while project remains on ESLint 9

## Why
Dependabot PR #57 fails CI due to peer resolution mismatch between `@eslint/js@10` and `eslint@9`. This blocks that major line until the toolchain is ready.
