### PR TITLE
fix: add NODE_AUTH_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,3 +47,5 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The publish step was missing `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env var. Without it, `npm publish` has no auth token despite `setup-node` configuring the registry URL.