### PR TITLE
v2.1.6: Updates publish workflow for macOS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,35 +15,27 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: npm
-
-      - name: Ensure modern npm
-        run: npm i -g npm@latest
-
-      - name: Install keytar runtime dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsecret-1-0
 
       - name: Install
         run: npm ci
 
       - name: Test
-        run: npm test --if-present
+        run: npm test
 
       - name: Build
         run: npm run build --if-present
 
       - name: Publish
-        run: npm publish --provenance
+        run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vault77/summon",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vault77/summon",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vault77/summon",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "A recovered VAULT77 relic for macOS operators. summonTheWarlord is a high-performance CLI tool for ultra-fast, low-fee Solana swaps on macOS. Private keys are secured using the native macOS Keychain, never written to disk or exposed to JavaScript memory longer than required. Built for serious CLI workflows with system notifications, local-first execution, and zero browser dependency.",
   "keywords": [
     "solana",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "summon-cli.js",
   "bin": {
-    "summon": "./summon-cli.js"
+    "summon": "summon-cli.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Updates the CI publish flow to run on macOS and modernizes related tooling while simplifying the workflow and normalizing package metadata.

Summary of changes:
- Switches CI runner from Linux to macOS to align publishing environment with macOS-native credential handling.
- Upgrades Node and GitHub Action versions (Node 20 → 24; checkout/setup-node actions bumped).
- Removes extra runtime setup steps (global npm upgrade and Linux-specific keytar/libsecret install).
- Simplifies test and publish steps (uses plain npm test and npm publish).
- Bumps package version to 2.1.6 and normalizes the package CLI bin path.

Why:
- Publishing from macOS avoids Linux-specific keytar setup and better supports the package's macOS-focused keychain behavior.
- Upgrading Node and actions keeps the workflow current and reduces manual maintenance.
- Removing unnecessary setup steps simplifies CI and reduces points of failure.
- Normalizing the bin path improves consistency across environments.

Review Focus:
- Confirm macOS runner is suitable for publish and does not break other CI expectations.
- Verify removal of the libsecret installation does not prevent native keytar functionality during publish.
- Check that the Node/action version bumps do not introduce unexpected CI/test failures.
- Confirm the npm publish behavior (provenance flag removed) and package metadata (version bump and bin path normalization) are correct for release.