### PR TITLE
deps: bump axios 1.19.0 and fs-extra 11.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.4",
-        "axios": "^1.18.1",
+        "axios": "^1.19.0",
         "bs58": "^6.0.0",
         "commander": "^15.0.0",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.4.0",
         "keytar": "^7.9.0",
         "open": "^11.0.0",
         "solana-swap": "1.3.0"
@@ -27,6 +27,9 @@
         "eslint-plugin-import": "^2.32.0",
         "globals": "^17.7.0",
         "jest": "^30.4.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2449,13 +2452,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -4208,9 +4211,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.4",
-    "axios": "^1.18.1",
+    "axios": "^1.19.0",
     "bs58": "^6.0.0",
     "commander": "^15.0.0",
-    "fs-extra": "^11.3.5",
+    "fs-extra": "^11.4.0",
     "keytar": "^7.9.0",
     "open": "^11.0.0",
     "solana-swap": "1.3.0"


### PR DESCRIPTION
- Bumps production dependencies after a supply-chain review:
  - `axios` `^1.18.1` → `^1.19.0` (locked `1.19.0`; npm signature + provenance; raises `form-data` floor to `^4.0.6`)
  - `fs-extra` `^11.3.5` → `^11.4.0` (locked `11.4.0`; small symlink edge-case fixes; no new install scripts)
- Lockfile only otherwise; no application code changes.

## Supply-chain notes
- Neither package introduces `hasInstallScript`.
- `axios@1.19.0` is ~4 days old (under Dependabot’s 7-day minor cooldown); accepted for this manual PR after integrity checks.
- Residual prod audit moderates (`uuid` via `@solana/web3.js` / `jayson`) remain unfixed upstream and are out of scope.

## Test plan
- [x] `npm test` (14 suites / 66 tests pass)
- [x] `npm run lint`
- [ ] CI green on this PR
- [ ] Optional: smoke config read/write and one swap quote path before patch release

## Release
Candidate for a **patch** release (e.g. `2.1.10`) after merge if you want consumers to pick up the locked tree via a new published version.